### PR TITLE
Enable fractional buy based on daily capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The backtest evaluates each hourly bar in **SELL then BUY** order.
 
 **BUY**
 
-Buy shares worth up to the specified Daily Capacity when the hourly price is less than or equal to `(1 - X/100)` times the day's open. For example, with a day open of `100`, `X = 2`, and a Daily Capacity of `200`, any hourly price of `98` or below will trigger a purchase of `200/98 ≈ 2.04` shares at that price. Only one BUY is allowed per day; after a BUY executes, additional BUYs are suppressed until the next trading day.
+Buy shares worth up to the specified Daily Capacity when the hourly price is less than or equal to `(1 - X/100)` times the day's open. For example, with a day open of `100`, `X = 2`, and a Daily Capacity of `200`, any hourly price of `98` or below will trigger a purchase of `200/98 ≈ 2.0` shares at that price (quantities are rounded to one decimal place). Only one BUY is allowed per day; after a BUY executes, additional BUYs are suppressed until the next trading day.
 
 **SELL**
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 streamlit run app.py
 ```
 
-Use the sidebar to choose ticker and X% threshold, then run the backtest to view results.
+Use the sidebar to choose ticker, X% threshold, Daily Capacity in dollars, and Y% threshold, then run the backtest to view results.
 
 ## Strategy Rules
 
@@ -22,11 +22,7 @@ The backtest evaluates each hourly bar in **SELL then BUY** order.
 
 **BUY**
 
-Buy `X` shares when the hourly price is less than or equal to `(1 - X/100)`
-times the day's open. For example, with a day open of `100` and `X = 2`, any
-hourly price of `98` or below will trigger a purchase of two shares at that
-price. Only one BUY is allowed per day; after a BUY executes, additional BUYs
-are suppressed until the next trading day.
+Buy shares worth up to the specified Daily Capacity when the hourly price is less than or equal to `(1 - X/100)` times the day's open. For example, with a day open of `100`, `X = 2`, and a Daily Capacity of `200`, any hourly price of `98` or below will trigger a purchase of `200/98 ≈ 2.04` shares at that price. Only one BUY is allowed per day; after a BUY executes, additional BUYs are suppressed until the next trading day.
 
 **SELL**
 

--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ def main():
     st.title("Hourly Backtest")
     st.caption("Evaluation order per bar: SELL then BUY")
 
-    ticker, x_percent, y_percent, run_btn = sidebar_inputs()
+    ticker, x_percent, capacity, y_percent, run_btn = sidebar_inputs()
 
     if run_btn:
         if not ticker:
@@ -41,7 +41,9 @@ def main():
             idx.date(): (row["Open"], row["Close"]) for idx, row in daily_df.iterrows()
         }
 
-        trades_df, kpis = run_backtest(hourly_df, daily_map, x_percent, y_percent)
+        trades_df, kpis = run_backtest(
+            hourly_df, daily_map, x_percent, capacity, y_percent
+        )
 
         st.subheader("Results")
         st.text(f"Timezone: {timezone}")
@@ -52,7 +54,7 @@ def main():
 
     with st.expander("Help"):
         st.write(
-            """Rules:\n- BUY X shares if hourly price ≤ (1 - X/100) × day open.\n- SELL floor(50%) of position when portfolio value ≥ Y% of book cost (default 110%).\nEvaluation order per bar: SELL then BUY."""
+            """Rules:\n- BUY shares worth up to Daily Capacity when hourly price ≤ (1 - X/100) × day open.\n- SELL floor(50%) of position when portfolio value ≥ Y% of book cost (default 110%).\nEvaluation order per bar: SELL then BUY."""
         )
 
 

--- a/core/backtest.py
+++ b/core/backtest.py
@@ -13,6 +13,7 @@ def run_backtest(
     hourly_df: pd.DataFrame,
     daily_map: Dict[pd.Timestamp, Tuple[float, float]],
     x_percent: int,
+    capacity: float,
     y_percent: int = 110,
 ):
     """Run the backtest and return trades and KPI summary.
@@ -25,6 +26,8 @@ def run_backtest(
         Mapping of ``date`` -> ``(open, close)``.
     x_percent : int
         BUY threshold X.
+    capacity : float
+        Dollar amount available for each BUY.
     y_percent : int, default 110
         SELL threshold Y as a percentage of book cost.
 
@@ -52,6 +55,7 @@ def run_backtest(
                 price,
                 portfolio,
                 x_percent,
+                capacity,
                 y_percent,
                 allow_buy=allow_buy,
             )

--- a/core/strategy.py
+++ b/core/strategy.py
@@ -53,12 +53,12 @@ def should_buy(price: float, day_open: float, x_percent: int) -> bool:
 def buy_qty(price: float, capacity: float) -> float:
     """Return quantity purchasable within ``capacity`` dollars at ``price``.
 
-    Quantity is rounded to two decimal places to simulate fractional share
+    Quantity is rounded to one decimal place to simulate fractional share
     purchases.
     """
     if price <= 0:
         return 0.0
-    return round(capacity / price, 2)
+    return round(capacity / price, 1)
 
 
 def apply_bar(

--- a/core/strategy.py
+++ b/core/strategy.py
@@ -41,7 +41,8 @@ def should_buy(price: float, day_open: float, x_percent: int) -> bool:
     A BUY is executed if the current hourly price is **less than or equal**
     to ``(1 - X/100)`` times the day's open. For example, with ``day_open=100``
     and ``X=2`` the threshold becomes ``98``. Any price of ``98`` or **below**
-    will satisfy the condition and we purchase ``X`` shares.
+    will satisfy the condition and permit a purchase up to the dollar
+    capacity.
     """
     if day_open is None:
         return False
@@ -49,9 +50,15 @@ def should_buy(price: float, day_open: float, x_percent: int) -> bool:
     return price <= threshold
 
 
-def buy_qty(x_percent: int) -> int:
-    """Buy floor(x_percent) shares."""
-    return int(x_percent)
+def buy_qty(price: float, capacity: float) -> float:
+    """Return quantity purchasable within ``capacity`` dollars at ``price``.
+
+    Quantity is rounded to two decimal places to simulate fractional share
+    purchases.
+    """
+    if price <= 0:
+        return 0.0
+    return round(capacity / price, 2)
 
 
 def apply_bar(
@@ -61,6 +68,7 @@ def apply_bar(
     price,
     portfolio: Portfolio,
     x_percent: int,
+    capacity: float,
     y_percent: int = 110,
     allow_buy: bool = True,
 ) -> List[Dict[str, Any]]:
@@ -80,6 +88,8 @@ def apply_bar(
         Portfolio instance to mutate.
     x_percent : int
         BUY threshold X in percent.
+    capacity : float
+        Dollar amount available for a BUY.
     y_percent : int, default 110
         SELL threshold Y in percent of book cost.
 
@@ -112,7 +122,7 @@ def apply_bar(
 
     # BUY evaluation (after potential sell)
     if allow_buy and should_buy(price, day_open, x_percent):
-        qty = buy_qty(x_percent)
+        qty = buy_qty(price, capacity)
         portfolio.buy(qty, price)
         transactions.append(
             {

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -15,10 +15,10 @@ def test_run_backtest_basic():
     ]
     hourly_df = pd.DataFrame({"Close": [98, 97, 120]}, index=idx)
     daily_map = {pd.Timestamp("2023-01-01").date(): (100, 102)}
-    trades_df, kpis = run_backtest(hourly_df, daily_map, 2, 110)
+    trades_df, kpis = run_backtest(hourly_df, daily_map, 2, 200, 110)
     assert list(trades_df["Action"]) == ["BUY", "SELL"]
-    assert kpis["Final PQ"] == 1
-    assert kpis["Total Buys"] == 2
+    assert kpis["Final PQ"] == 1.04
+    assert kpis["Total Buys"] == 2.04
     assert kpis["Total Sells"] == 1
 
 
@@ -33,7 +33,7 @@ def test_hold_row_added():
         pd.Timestamp("2023-01-01").date(): (100, 102),
         pd.Timestamp("2023-01-02").date(): (104, 106),
     }
-    trades_df, _ = run_backtest(hourly_df, daily_map, 2, 110)
+    trades_df, _ = run_backtest(hourly_df, daily_map, 2, 200, 110)
     # Expect a HOLD row for second day since no trades occur on 2023-01-02
     actions = list(trades_df["Action"])
     assert actions[0] == "BUY"

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -17,8 +17,8 @@ def test_run_backtest_basic():
     daily_map = {pd.Timestamp("2023-01-01").date(): (100, 102)}
     trades_df, kpis = run_backtest(hourly_df, daily_map, 2, 200, 110)
     assert list(trades_df["Action"]) == ["BUY", "SELL"]
-    assert kpis["Final PQ"] == 1.04
-    assert kpis["Total Buys"] == 2.04
+    assert kpis["Final PQ"] == 1.0
+    assert kpis["Total Buys"] == 2.0
     assert kpis["Total Sells"] == 1
 
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -26,27 +26,28 @@ def test_rules():
 
     assert sell_qty(10) == 5
     assert sell_qty(3) == 1
-    assert buy_qty(5) == 5
+    assert buy_qty(100, 250) == 2.5
 
 
 def test_apply_bar_sell_then_buy():
     p = Portfolio()
     p.buy(2, 10)
     ts = pd.Timestamp("2023-01-01 11:00")
-    txns = apply_bar(ts, 100, 102, 98, p, 2, 110)
+    txns = apply_bar(ts, 100, 102, 98, p, 2, 250, 110)
     # Should sell then buy => two transactions
     assert len(txns) == 2
     assert txns[0]["Action"] == "SELL"
     assert txns[0]["Transaction Quantity"] == 1
     assert txns[1]["Action"] == "BUY"
-    # After sell then buy: qty should be 3
-    assert p.qty == 3
+    assert txns[1]["Transaction Quantity"] == 2.55
+    # After sell then buy: qty should be 3.55
+    assert p.qty == 3.55
 
 
 def test_apply_bar_buy_blocked():
     p = Portfolio()
     ts = pd.Timestamp("2023-01-01 11:00")
     # Even though price triggers a buy, allow_buy=False prevents it
-    txns = apply_bar(ts, 100, 102, 98, p, 2, 110, allow_buy=False)
+    txns = apply_bar(ts, 100, 102, 98, p, 2, 250, 110, allow_buy=False)
     assert txns == []
     assert p.qty == 0

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -39,9 +39,9 @@ def test_apply_bar_sell_then_buy():
     assert txns[0]["Action"] == "SELL"
     assert txns[0]["Transaction Quantity"] == 1
     assert txns[1]["Action"] == "BUY"
-    assert txns[1]["Transaction Quantity"] == 2.55
-    # After sell then buy: qty should be 3.55
-    assert p.qty == 3.55
+    assert txns[1]["Transaction Quantity"] == 2.6
+    # After sell then buy: qty should be 3.6
+    assert p.qty == 3.6
 
 
 def test_apply_bar_buy_blocked():

--- a/ui/controls.py
+++ b/ui/controls.py
@@ -11,8 +11,11 @@ def sidebar_inputs():
     x_percent = st.sidebar.number_input(
         "X (%)", min_value=1, max_value=20, value=2, step=1
     )
+    capacity = st.sidebar.number_input(
+        "Daily Capacity ($)", min_value=0.0, value=100.0, step=10.0
+    )
     y_percent = st.sidebar.number_input(
         "Y (%)", min_value=101, max_value=200, value=110, step=1
     )
     run_btn = st.sidebar.button("Run Backtest")
-    return ticker, int(x_percent), int(y_percent), run_btn
+    return ticker, int(x_percent), float(capacity), int(y_percent), run_btn


### PR DESCRIPTION
## Summary
- allow buying fractional shares based on a user-specified daily dollar capacity
- wire the new capacity input through the UI, backtest engine, and strategy
- document fractional-buy behavior in the README and app help text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b62df45c4083239e5a96d9c8e1c838